### PR TITLE
Scene metadata (without downloading the shit ton of TIFF data)

### DIFF
--- a/landsat_parser/main.py
+++ b/landsat_parser/main.py
@@ -1,9 +1,8 @@
 from typing import DefaultDict, List
-
 from collections import defaultdict
-from datetime import timedelta
+from datetime import datetime
 
-from skyfield.iokit import os
+from shapely.geometry import Polygon
 from landsatxplore.api import API
 from landsatxplore.earthexplorer import EarthExplorer
 from skyfield.api import Time, Topos, load
@@ -46,54 +45,116 @@ def predict_passover(lat: float, lon: float, start_time: Time, end_time: Time):
     return dict(results)
 
 
-SERVICE_URL = "https://m2m.cr.usgs.gov/api/api/json/development/"
-
-
-if __name__ == "__main__":
-    curdir = os.path.dirname(os.path.abspath(__file__))
-    filename = os.path.join(curdir, "data/tle.txt")
-    satellites = load_sat_data(filename)
-
-    # Define the latitude and longitude
-    lat = 42.59113799085078
-    lon = -83.19858770096863
-
-    # Define your EarthExplorer credentials
+def get_last_scene_metadata(lat: float, lon: float):
     username = "spaceapps43"
     password = "EdBB4#XDQcz@Kr"
-
-    # Load timescale
-
-    ts = load.timescale()
-    # start_time = ts.now()
-    # end_time = ts.utc(ts.now().utc_datetime() + timedelta(days=2))
-    start_time = ts.utc(ts.now().utc_datetime() - timedelta(days=35))
-    end_time = ts.now()
-
-    print(predict_passover(lat, lon, start_time, end_time))
 
     api = API(username, password)
 
     scenes = api.search(
         dataset="landsat_ot_c2_l2",
+        max_results=1,
         latitude=lat,
         longitude=lon,
-        start_date="2024-09-05",
-        end_date="2024-09-06",
+        start_date=datetime.now().strftime("%Y-%m-%d"),
         max_cloud_cover=20,
     )
 
-    print(f"{len(scenes)} found")
+    # for scene in scenes:
+    #     print(scene["acquisition_date"].strftime("%Y-%m-%d"))
+    #     # Write scene footprints to disk
+    #     fname = f"{scene['display_id']}.geojson"
+    #     print(scene)
+    #     # with open(fname, "w") as f:
+    #     #     json.dump(scene["spatial_coverage"].__geo_interface__, f)
+    if not scenes:
+        return None
 
-    for scene in scenes:
-        print(scene["acquisition_date"].strftime("%Y-%m-%d"))
-        # Write scene footprints to disk
-        fname = f"{scene['display_id']}.geojson"
-        print(scene)
-        # with open(fname, "w") as f:
-        #     json.dump(scene["spatial_coverage"].__geo_interface__, f)
+    scene = scenes[0]
+    bounds: Polygon = scene["spatial_coverage"]
 
-    # Initialize the EarthExplorer instance
-    ee = EarthExplorer(username, password)
-    # Download a specific scene by scene's entity_id
-    ee.download("LC90200302024249LGN00", "./scene_out", dataset="landsat_ot_c2_l2")
+    scene = {
+        "spatial_coverage": list(bounds.exterior.coords),
+        "acquisition_date": str(scene["acquisition_date"]),
+        "cloud_cover": scene["cloud_cover"],
+        "wrs_path": scene["wrs_path"],
+        "wrs_row": scene["wrs_path"],
+        "land_cloud_cover": scene["land_cloud_cover"],
+        "scene_cloud_cover": scene["scene_cloud_cover"],
+        "entity_id": scene["entity_id"],
+        "display_id": scene["display_id"],
+    }
+    return scene
+
+    # "cloud_cover": 0,
+    # "entity_id": "LC80200282024273LGN00",
+    # "display_id": "LC08_L2SP_020028_20240929_20241005_02_T1",
+    # "ordering_id": "None",
+    # "landsat_product_id": "LC08_L1TP_020028_20240929_20241005_02_T1",
+    # "landsat_scene_id": "LC80200282024273LGN00",
+    # "acquisition_date": datetime(2024, 9, 29, 0, 0),
+    # "collection_category": datetime(2024, 10, 1, 0, 0),
+    # "collection_number": 2,
+    # "wrs_path": 20,
+    # "wrs_row": 28,
+    # "target_wrs_path": 20,
+    # "target_wrs_row": 28,
+    # "nadir-off_nadir": "NADIR",
+    # "roll_angle": -0.001,
+    # "date_product_generated": datetime(2024, 10, 5, 0, 0),
+    # "start_time": datetime(2024, 9, 29, 16, 14, 53),
+    # "stop_time": datetime(2024, 9, 29, 16, 15, 25),
+    # "station_id": "LGN",
+    # "day-night_indicator": "DAY",
+    # "land_cloud_cover": 0.01,
+    # "scene_cloud_cover": 0.01,
+    # "ground_control_points_model": 851,
+    # "ground_control_points_version": 5,
+    # "geometric_rmse_model": 7.438,
+    # "geometric_rmse_model_x": 4.982,
+    # "geometric_rmse_model_y": 5.523,
+    # "processing_software_version": "LPGS_16.4.0",
+    # "sun_elevation_l0ra": 39.20054755,
+    # "sun_azimuth_l0ra": 159.33949597,
+    # "tirs_ssm_model": "FINAL",
+    # "data_type": "OLI_TIRS_L2SP",
+    # "sensor_id": "OLI_TIRS",
+    # "satellite": 8,
+    # "product_map_projection": "UTM",
+    # "utm_zone": 17,
+    # "datum": "WGS84",
+    # "ellipsoid": "WGS84",
+    # "scene_center_latitude": 46.02948,
+    # "scene_center_longitude": -82.15787,
+    # "corner_upper_left_latitude": 47.07639,
+    # "corner_upper_left_longitude": -83.74122,
+    # "corner_upper_right_latitude": 47.10859,
+    # "corner_upper_right_longitude": -80.62305,
+    # "corner_lower_left_latitude": 44.92139,
+    # "corner_lower_left_longitude": -83.63674,
+    # "corner_lower_right_latitude": 44.95126,
+    # "corner_lower_right_longitude": -80.63743,
+    # "has_customized_metadata": None,
+    # "options": {"bulk": True, "download": True, "order": False, "secondary": False},
+    # "selected": {"bulk": False, "compare": False, "order": False},
+    # "spatial_bounds": (-83.65527, 44.9521, -80.62815, 47.09059),
+    # "spatial_coverage": "<POLYGON ((-83.655 45.382, -81.298 44.952, -80.628 46.657, -83.058 47.091, -...>",
+    # "temporal_coverage": [datetime(2024, 9, 29, 0, 0), datetime(2024, 9, 29, 0, 0)],
+    # "publish_date": datetime(2024, 10, 5, 16, 9, 23),
+
+
+SERVICE_URL = "https://m2m.cr.usgs.gov/api/api/json/development/"
+
+if __name__ == "__main__":
+    # Define the latitude and longitude
+    lat = 46.00
+    lon = -83.00
+
+    print(get_last_scene_metadata(lat, lon))
+
+    # # Initialize the EarthExplorer instance
+    # username = "spaceapps43"
+    # password = "EdBB4#XDQcz@Kr"
+    # ee = EarthExplorer(username, password)
+    # # Download a specific scene by scene's entity_id
+    # ee.download("LC90200302024249LGN00", "./scene_out", dataset="landsat_ot_c2_l2")

--- a/landsat_webapp/app.py
+++ b/landsat_webapp/app.py
@@ -11,6 +11,8 @@ from skyfield.api import load
 
 from landsat_parser.main import predict_passover
 
+from landsat_parser.main import get_last_scene_metadata
+
 load_dotenv()
 
 app = Flask(__name__)
@@ -105,6 +107,14 @@ def predict_passover_endpoint():
 
     # Return the first occurrence of passovers for both satellites
     return jsonify(prediction_results)
+
+@app.get("/metadata")
+def get_metadata():
+    lat = float(request.args.get('lat', 0))
+    lon = float(request.args.get('lon', 0))
+
+    results = get_last_scene_metadata(lat, lon)
+    return jsonify(results)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Get metadata from one scene, given lat and lon
    - `/metadata`
   
this is the return format:
```
{
        "spatial_coverage": list of 5 coords
        "acquisition_date": str
        "cloud_cover": float
        "wrs_path": int
        "wrs_row": int
        "land_cloud_cover": float
        "scene_cloud_cover": float
        "entity_id": string
        "display_id": string
    }
```